### PR TITLE
Copy the exit code of the child process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ typings/
 
 # dotenv environment variables file
 .env
-
+.idea

--- a/cli.js
+++ b/cli.js
@@ -22,5 +22,8 @@ function run(args, isCi) {
 module.exports = run;
 
 if (require.main === module) {
-	run(process.argv.slice(2), isCi);
+	const proc = run(process.argv.slice(2), isCi);
+	if (proc) {
+		proc.on('exit', process.exit);
+	}
 }


### PR DESCRIPTION
Some build tools rely on the exit code of commands to tell if the build succeeded or failed, but currently `is-ci` always returns a status of `0`. 

This makes the exit code of `is-ci` clone that of the `npm run-script` command that it executes. 
