### PR TITLE
Use npm.cmd for windows

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -4,7 +4,7 @@
 const childProcess = require('child_process');
 const isCi = require('is-ci');
 const isWindows = process.platform === 'win32';
-const npmExec = isWindows ? 'npm.cmd' : 'npm'
+const npmExec = isWindows ? 'npm.cmd' : process.env.npm_execpath ? process.env.npm_execpath : 'npm';
 
 function run(args, isCi) {
 	const script = isCi ? args[0] : args[1];

--- a/cli.js
+++ b/cli.js
@@ -3,19 +3,21 @@
 'use strict';
 const childProcess = require('child_process');
 const isCi = require('is-ci');
+const isWindows = process.platform === 'win32';
+const npmExec = isWindows ? 'npm.cmd' : 'npm'
 
 function run(args, isCi) {
 	const script = isCi ? args[0] : args[1];
 
 	if (script) {
 		return childProcess.spawn(
-      process.env.npm_execpath || 'npm',
-      ['run', script],
+			npmExec,
+			['run', script],
 			{
-				detached: true,
+				detached: !isWindows,
 				stdio: 'inherit'
 			}
-    );
+		);
 	}
 }
 


### PR DESCRIPTION
Windows needs the `.cmd` ending for the `npm` binary.
Also [detached](https://nodejs.org/api/child_process.html#child_process_options_detached) on Windows makes the process open a new terminal, and doesn't do the right thing with STDOUT/STDERR, so I fixed that. 

Tested locally on my Windows box, and it seems to be okay. OSX still worked as before.

![is-ci-cli test](https://cloud.githubusercontent.com/assets/13004162/26748926/b00abc46-47b7-11e7-9610-3cc13685bee8.png)

Hopefully closes #2 