### PR TITLE
Better cross platform spawn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ typings/
 # dotenv environment variables file
 .env
 .idea
+
+# Lock files
+package-lock.json
+yarn.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Install
 
-Ensure you have [Node.js](https://nodejs.org) version 4+ installed. Then run the following:
+Ensure you have [Node.js](https://nodejs.org) version 8+ installed. Then run the following:
 
 ```
 $ npm install --dev is-ci-cli

--- a/cli.js
+++ b/cli.js
@@ -1,21 +1,22 @@
 #!/usr/bin/env node
 
 'use strict';
-const childProcess = require('child_process');
-const isCi = require('is-ci');
 
-const isWindows = process.platform === 'win32';
-const npmExec = isWindows ? 'npm.cmd' : process.env.npm_execpath ? process.env.npm_execpath : 'npm';
+process.on('unhandledRejection', err => {
+	throw err;
+});
+
+const spawn = require('cross-spawn');
+const isCi = require('is-ci');
 
 function run(args, isCi) {
 	const script = isCi ? args[0] : args[1];
 
 	if (script) {
-		return childProcess.spawn(
-			npmExec,
+		return spawn(
+			'npm',
 			['run', script],
 			{
-				detached: !isWindows,
 				stdio: 'inherit'
 			}
 		);
@@ -25,8 +26,8 @@ function run(args, isCi) {
 module.exports = run;
 
 if (require.main === module) {
-	const proc = run(process.argv.slice(2), isCi);
-	if (proc) {
-		proc.on('exit', process.exit);
+	const child = run(process.argv.slice(2), isCi);
+	if (child) {
+		child.on('exit', process.exit);
 	}
 }

--- a/cli.js
+++ b/cli.js
@@ -10,11 +10,12 @@ const spawn = require('cross-spawn');
 const isCi = require('is-ci');
 
 function run(args, isCi) {
+	const npmExec = process.env.npm_execpath || 'npm';
 	const script = isCi ? args[0] : args[1];
 
 	if (script) {
 		return spawn(
-			'npm',
+			npmExec,
 			['run', script],
 			{
 				stdio: 'inherit'

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "is-ci": "cli.js"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "files": [
     "cli.js"
@@ -19,7 +19,8 @@
     "npm-scripts"
   ],
   "dependencies": {
-    "is-ci": "^1.0.10"
+    "cross-spawn": "^7.0.0",
+    "is-ci": "^2.0.0"
   },
   "devDependencies": {
     "ava": "^0.19.1",


### PR DESCRIPTION
We have ran into issues with spawning in Windows on TravisCI. (https://github.com/tannerlinsley/react-table/pull/1559)

In these changes I have:

- Installed `cross-spawn` for a better cross-platform spawning solution
- Make the process fail loudly for errors that try to fail silently
- Bumped the `is-ci` version (Drops the no longer supported Node versions)
- Bumped the minimum Node version to 8 (Required by `cross-spawn` and `is-ci`)
- Prevent generation of and ignore lock files