### PR TITLE
Add integration-ish test for additional arguments

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -28,7 +28,7 @@ function run(args, isCi, spawn, npmExec = 'npm') {
 	if (script) {
 		return spawn(
 			npmExec,
-			['run', [script, ...scriptArgs]],
+			['run', script, ...scriptArgs],
 			{
 				stdio: 'inherit'
 			}

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "lint": "xo",
     "pretest": "npm run lint",
     "test": "ava",
-    "ci:test": "node cli.js ci:pass ci:fail",
-    "ci:fail": "exit 1",
-    "ci:pass": "exit 0"
+    "ci:test": "node cli.js ci:check-args ci:fail --arg1",
+    "ci:fail": "echo \"CI ran incorrect run-script, failing\"; exit 1;",
+    "ci:check-args": "node -e 'assert(process.argv[1] === \"--arg1\", `\"${process.argv[1]}\" should match \"--arg1\"`)' --"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "test": "ava",
     "ci:test": "node cli.js ci:check-args ci:fail --arg1",
     "ci:fail": "echo \"CI ran incorrect run-script, failing\"; exit 1;",
-    "ci:check-args": "node -e 'assert(process.argv[1] === \"--arg1\", `\"${process.argv[1]}\" should match \"--arg1\"`)' --"
+    "ci:check-args": "node -e \"assert(process.argv[1] === '--arg1', 'process.argv[1]' + ' should match --arg1')\" --"
   }
 }

--- a/test.js
+++ b/test.js
@@ -15,12 +15,12 @@ test.afterEach('reset fake', () => {
 
 test('runs first argument when in CI environment', t => {
 	run(['first', 'second'], true, spawn);
-	t.true(spawn.returned(['run', ['first']]));
+	t.true(spawn.returned(['run', 'first']));
 });
 
 test('runs second argument when not in CI environment', t => {
 	run(['first', 'second'], false, spawn);
-	t.true(spawn.returned(['run', ['second']]));
+	t.true(spawn.returned(['run', 'second']));
 });
 
 test('runs nothing if no second argument and not in CI environment', t => {
@@ -30,14 +30,14 @@ test('runs nothing if no second argument and not in CI environment', t => {
 
 test('runs script with additional arguments if provided', t => {
 	run(['first', 'second', '--test', 'value'], true, spawn, 'npm');
-	t.true(spawn.lastCall.returned(['run', ['first', '--', '--test', 'value']]));
+	t.true(spawn.lastCall.returned(['run', 'first', '--', '--test', 'value']));
 
 	run(['first', 'second', '--test', 'value'], false, spawn, 'npm');
-	t.true(spawn.lastCall.returned(['run', ['second', '--', '--test', 'value']]));
+	t.true(spawn.lastCall.returned(['run', 'second', '--', '--test', 'value']));
 
 	run(['first', 'second', '--test', 'value'], true, spawn, 'yarn');
-	t.true(spawn.lastCall.returned(['run', ['first', '--test', 'value']]));
+	t.true(spawn.lastCall.returned(['run', 'first', '--test', 'value']));
 
 	run(['first', 'second', '--test', 'value'], false, spawn, 'yarn');
-	t.true(spawn.lastCall.returned(['run', ['second', '--test', 'value']]));
+	t.true(spawn.lastCall.returned(['run', 'second', '--test', 'value']));
 });

--- a/test.js
+++ b/test.js
@@ -6,7 +6,7 @@ import run from './cli';
 let spawn;
 
 test.before('fake spawn', () => {
-	spawn = sinon.fake((name, args) => args.slice(-2));
+	spawn = sinon.fake((name, args) => args);
 });
 
 test.afterEach('reset fake', () => {


### PR DESCRIPTION
Also fixes this concat/arg error when passing in additional args to scripts:

```sh
error Command "ci:pass,--watch" not found.
```