### PR TITLE
Rename bin script to avoid naming collision in npm@7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8, 10, 12, 14]
+        node-version: [8, 10, 12, 14, 15]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In your package.json:
 
 ```js
 "scripts": {
-  "test": "is-ci test:ci test:local"
+  "test": "is-ci-cli test:ci test:local"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "repository": "YellowKirby/is-ci-cli",
   "bin": {
-    "is-ci": "cli.js"
+    "is-ci": "cli.js",
+    "is-ci-cli": "cli.js"
   },
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
Adds an alternative bin name for the script so that `npm@7` correctly links to this package. When using `npm@7`, this new name is required. But the original `is-ci` name is kept around as well, which can be used without issue in earlier versions of npm.

Closes #13